### PR TITLE
Fix: External Mergesort bug

### DIFF
--- a/Backend/ExternalMergeSort.cpp
+++ b/Backend/ExternalMergeSort.cpp
@@ -14,16 +14,53 @@ void ExternalMergeSort::sort_block()
 {
     for ( int i = 0; i < m_input.size(); i++ ) {
         m_RAM.push_back( m_input.at( i ) );
+    
         if ( m_RAM.size() == m_numLimit || i == m_input.size() - 1 ) {
             m_blockNumber++;
-            std::sort( m_RAM.begin(), m_RAM.end() );
+            
+            m_tmpRAM.resize( m_RAM.size() );
+            mergeSort( m_RAM, m_tmpRAM, 0, m_RAM.size() - 1 );
+                        
             m_tempFile[ 0 ].insert( m_tempFile[ 0 ].end(), m_RAM.begin(), m_RAM.end() );
-            m_RAM.clear();
         }
+        m_RAM.clear();
+        m_tmpRAM.clear();
     }
     m_RAM.clear();
     m_fileToSort = 0;
     m_fileSorted = 1;
+}
+
+void ExternalMergeSort::mergeSort( InputVectorType& RAM, InputVectorType& tmpRAM, int left, int right )
+{
+    if ( right <= left ) 
+        return;
+    
+    int center = left + (right - left) / 2;
+    mergeSort( RAM, tmpRAM, left, center );
+    mergeSort( RAM, tmpRAM, center + 1, right );
+    merge( RAM, tmpRAM, left, center, right );
+}
+
+void ExternalMergeSort::merge( InputVectorType& RAM, InputVectorType& tmpRAM, int left, int center, int right )
+{
+    // copy to tmpRAM[]
+    for ( int temp = left; temp <= right; temp++ ) {
+        tmpRAM[ temp ] = RAM[ temp ];
+    }
+    
+    // merge back 
+    int i = left, j = center + 1;
+    for ( int k = left; k <= right; k++ ) {
+        if ( i > center )
+            RAM[ k ] = tmpRAM[ j++ ];
+        else if ( j > right )
+            RAM[ k ] = tmpRAM[ i++ ];
+        else if ( tmpRAM[ j ] < tmpRAM[ i ] )
+            RAM[ k ] = tmpRAM[ j++ ];
+        else
+            RAM[ k ] = tmpRAM[ i++ ];
+    }
 }
 
 void ExternalMergeSort::merge_RAM()
@@ -147,7 +184,7 @@ void ExternalMergeSort::merge()
 
 void ExternalMergeSort::operator()()
 {
-    std::cout << "[TASKRUNNER] Excuting External Mergesorting..." << std::endl;
+    std::cout << "[TASKRUNNER] Executing External Mergesort" << std::endl;
     
     sort_block();
     merge();

--- a/Backend/ExternalMergeSort.h
+++ b/Backend/ExternalMergeSort.h
@@ -12,7 +12,6 @@
 
 namespace inf2b
 {
-
     class ExternalMergeSort 
     {
     private:
@@ -22,6 +21,7 @@ namespace inf2b
         InputVectorType m_RAM_A;
         InputVectorType m_RAM_B;
         InputVectorType m_RAM_C;
+        InputVectorType m_tmpRAM;
         int m_numLimit; //how many elements could fit in RAM
         int m_numLimit_A;
         int m_numLimit_B;
@@ -40,7 +40,20 @@ namespace inf2b
         
         void merge_block(int i);
         
+        /** 
+         * Merge different blocks. It makes use of merge_block(int)
+         */
         void merge();
+        
+        /**
+         * Perform mergesort on a subset of given input
+         */
+        void mergeSort( InputVectorType& RAM, InputVectorType& tmpRAM, int left, int right );
+        
+        /**
+         * merge step for the mergeSort(...)
+         */
+        void merge( InputVectorType& RAM, InputVectorType& tmpRAM, int left, int center, int right );
         
     public:
         ExternalMergeSort( InputVectorType& in, double ram ): m_input( in ) 


### PR DESCRIPTION
YW's version used c++ std::sort() to sort a block of given input. According to specification, implementation may vary across implementations.
GNU C++ library uses 3-part hybrid sorting algorithm which is a combination of introsort and insertion sort.

This fix replaces std::sort() with implementation of classical merge sort algorithm to sort a block of given numbers.

FIXME: It seems that algobench generated input is faulty _as in_ all elements of the generated vector are same.